### PR TITLE
Use "," as sed delimiter instead of "/"

### DIFF
--- a/debian/libpam-yubico.postinst
+++ b/debian/libpam-yubico.postinst
@@ -9,7 +9,7 @@ set -e
 # Write a new /usr/share/pam-configs/yubico from our template with the
 # configuration gathered using debconf in libpam-yubico.config
 db_get libpam-yubico/module_args
-sed -e "s/#DEBCONF_REPLACE/$RET/g" \
+sed -e "s,#DEBCONF_REPLACE,$RET,g" \
     < /usr/share/libpam-yubico/pam-auth-update.template \
     > /usr/share/pam-configs/yubico
 


### PR DESCRIPTION
The postinst script of libpam_yubikey will generate an error when module_args contains a "/":
"sed: -e expression #1, char 76: unknown option to `s'"
module_args can contain a "/" in the base64 encoded API key. E.g. "mode=client try_first_pass id=12345 key=abcdef0123456789/+aaaaaaaaa=". Using a different delimiter that does not occur in the replacement solves the problem.
